### PR TITLE
Add support for more operators in check macros

### DIFF
--- a/include/snitch/snitch.hpp
+++ b/include/snitch/snitch.hpp
@@ -1075,6 +1075,8 @@ struct assertion_location {
     std::size_t      line = 0u;
 };
 
+enum class test_case_state { success, failed, skipped };
+
 namespace event {
 struct test_run_started {
     std::string_view name = {};
@@ -1097,10 +1099,9 @@ struct test_case_started {
 };
 
 struct test_case_ended {
-    const test_id& id;
-    bool           success         = true;
-    bool           skipped         = false;
-    std::size_t    assertion_count = 0;
+    const test_id&  id;
+    test_case_state state           = test_case_state::success;
+    std::size_t     assertion_count = 0;
 #if SNITCH_WITH_TIMINGS
     float duration = 0.0f;
 #endif

--- a/include/snitch/snitch.hpp
+++ b/include/snitch/snitch.hpp
@@ -1087,6 +1087,9 @@ struct test_run_ended {
     std::size_t      fail_count      = 0;
     std::size_t      skip_count      = 0;
     std::size_t      assertion_count = 0;
+#if SNITCH_WITH_TIMINGS
+    float duration = 0.0f;
+#endif
 };
 
 struct test_case_started {
@@ -1095,6 +1098,9 @@ struct test_case_started {
 
 struct test_case_ended {
     const test_id& id;
+    bool           success         = true;
+    bool           skipped         = false;
+    std::size_t    assertion_count = 0;
 #if SNITCH_WITH_TIMINGS
     float duration = 0.0f;
 #endif

--- a/src/snitch.cpp
+++ b/src/snitch.cpp
@@ -40,7 +40,7 @@ colored<T> make_colored(const T& t, bool with_color, color_t start) {
     return {t, with_color ? start : "", with_color ? color::reset : ""};
 }
 
-thread_local snitch::impl::test_run* thread_current_test = nullptr;
+thread_local snitch::impl::test_state* thread_current_test = nullptr;
 } // namespace
 
 namespace {
@@ -226,8 +226,8 @@ void stdout_print(std::string_view message) noexcept {
     std::printf("%.*s", static_cast<int>(message.length()), message.data());
 }
 
-test_run& get_current_test() noexcept {
-    test_run* current = thread_current_test;
+test_state& get_current_test() noexcept {
+    test_state* current = thread_current_test;
     if (current == nullptr) {
         terminate_with("no test case is currently running on this thread");
     }
@@ -235,11 +235,11 @@ test_run& get_current_test() noexcept {
     return *current;
 }
 
-test_run* try_get_current_test() noexcept {
+test_state* try_get_current_test() noexcept {
     return thread_current_test;
 }
 
-void set_current_test(test_run* current) noexcept {
+void set_current_test(test_state* current) noexcept {
     thread_current_test = current;
 }
 
@@ -404,7 +404,7 @@ std::string_view extract_next_name(std::string_view& names) noexcept {
     return result;
 }
 
-small_string<max_capture_length>& add_capture(test_run& state) noexcept {
+small_string<max_capture_length>& add_capture(test_state& state) noexcept {
     if (state.captures.available() == 0) {
         state.reg.print(
             make_colored("error:", state.reg.with_color, color::fail),
@@ -561,20 +561,20 @@ bool run_tests(registry& r, std::string_view run_name, F&& predicate) noexcept {
         assertion_count += state.asserts;
 
         switch (t.state) {
-        case test_state::success: {
+        case impl::test_case_state::success: {
             // Nothing to do
             break;
         }
-        case test_state::failed: {
+        case impl::test_case_state::failed: {
             ++fail_count;
             success = false;
             break;
         }
-        case test_state::skipped: {
+        case impl::test_case_state::skipped: {
             ++skip_count;
             break;
         }
-        case test_state::not_run: {
+        case impl::test_case_state::not_run: {
             // Unreachable
             break;
         }
@@ -665,18 +665,18 @@ make_full_name(small_string<max_test_name_length>& buffer, const test_id& id) no
     return buffer.str();
 }
 
-void set_state(test_case& t, test_state s) noexcept {
-    if (static_cast<std::underlying_type_t<test_state>>(t.state) <
-        static_cast<std::underlying_type_t<test_state>>(s)) {
+void set_state(test_case& t, impl::test_case_state s) noexcept {
+    if (static_cast<std::underlying_type_t<impl::test_case_state>>(t.state) <
+        static_cast<std::underlying_type_t<impl::test_case_state>>(s)) {
         t.state = s;
     }
 }
 
-test_case_state convert_to_public_state(test_state s) noexcept {
+snitch::test_case_state convert_to_public_state(impl::test_case_state s) noexcept {
     switch (s) {
-    case test_state::success: return test_case_state::success;
-    case test_state::failed: return test_case_state::failed;
-    case test_state::skipped: return test_case_state::skipped;
+    case impl::test_case_state::success: return snitch::test_case_state::success;
+    case impl::test_case_state::failed: return snitch::test_case_state::failed;
+    case impl::test_case_state::skipped: return snitch::test_case_state::skipped;
     default: terminate_with("test case state cannot be exposed to the public");
     }
 }
@@ -773,12 +773,12 @@ void registry::print_details_expr(const expression& exp) const noexcept {
 }
 
 void registry::report_failure(
-    impl::test_run&           state,
+    impl::test_state&         state,
     const assertion_location& location,
     std::string_view          message) const noexcept {
 
     if (!state.may_fail) {
-        set_state(state.test, test_state::failed);
+        set_state(state.test, impl::test_case_state::failed);
     }
 
     if (!report_callback.empty()) {
@@ -799,13 +799,13 @@ void registry::report_failure(
 }
 
 void registry::report_failure(
-    impl::test_run&           state,
+    impl::test_state&         state,
     const assertion_location& location,
     std::string_view          message1,
     std::string_view          message2) const noexcept {
 
     if (!state.may_fail) {
-        set_state(state.test, test_state::failed);
+        set_state(state.test, impl::test_case_state::failed);
     }
 
     small_string<max_message_length> message;
@@ -829,12 +829,12 @@ void registry::report_failure(
 }
 
 void registry::report_failure(
-    impl::test_run&           state,
+    impl::test_state&         state,
     const assertion_location& location,
     const impl::expression&   exp) const noexcept {
 
     if (!state.may_fail) {
-        set_state(state.test, test_state::failed);
+        set_state(state.test, impl::test_case_state::failed);
     }
 
     if (!report_callback.empty()) {
@@ -864,11 +864,11 @@ void registry::report_failure(
 }
 
 void registry::report_skipped(
-    impl::test_run&           state,
+    impl::test_state&         state,
     const assertion_location& location,
     std::string_view          message) const noexcept {
 
-    set_state(state.test, test_state::skipped);
+    set_state(state.test, impl::test_case_state::skipped);
 
     if (!report_callback.empty()) {
         const auto captures_buffer = make_capture_buffer(state.captures);
@@ -883,7 +883,7 @@ void registry::report_skipped(
     }
 }
 
-test_run registry::run(test_case& test) noexcept {
+test_state registry::run(test_case& test) noexcept {
     small_string<max_test_name_length> full_name;
 
     if (!report_callback.empty()) {
@@ -895,7 +895,7 @@ test_run registry::run(test_case& test) noexcept {
             make_colored(full_name, with_color, color::highlight1), "\n");
     }
 
-    test.state = test_state::success;
+    test.state = impl::test_case_state::success;
 
     bool may_fail    = false;
     bool should_fail = false;
@@ -907,12 +907,12 @@ test_run registry::run(test_case& test) noexcept {
         }
     });
 
-    test_run state{.reg = *this, .test = test, .may_fail = may_fail, .should_fail = should_fail};
+    test_state state{.reg = *this, .test = test, .may_fail = may_fail, .should_fail = should_fail};
 
     // Store previously running test, to restore it later.
     // This should always be a null pointer, except when testing snitch itself.
-    test_run* previous_run = thread_current_test;
-    thread_current_test    = &state;
+    test_state* previous_run = thread_current_test;
+    thread_current_test      = &state;
 
 #if SNITCH_WITH_TIMINGS
     using clock     = std::chrono::high_resolution_clock;
@@ -951,12 +951,12 @@ test_run registry::run(test_case& test) noexcept {
     } while (!state.sections.levels.empty());
 
     if (state.should_fail) {
-        if (state.test.state == test_state::success) {
+        if (state.test.state == impl::test_case_state::success) {
             state.should_fail = false;
             report_failure(state, {__FILE__, __LINE__}, "expected test to fail, but it passed");
             state.should_fail = true;
-        } else if (state.test.state == test_state::failed) {
-            state.test.state = test_state::success;
+        } else if (state.test.state == impl::test_case_state::failed) {
+            state.test.state = impl::test_case_state::success;
         }
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,7 +64,8 @@ set(RUNTIME_TEST_FILES
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/section.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/cli.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/registry.cpp
-  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/macros.cpp)
+  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/macros.cpp
+  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/regressions.cpp)
 
 # Test snitch with doctest
 add_executable(snitch_runtime_tests ${PROJECT_SOURCE_DIR}/src/snitch.cpp ${RUNTIME_TEST_FILES})

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -308,6 +308,42 @@ TEST_CASE("check unary", "[test macros]") {
         CHECK_EXPR_SUCCESS(catcher);
     }
 
+    SECTION("integer expression ^ pass") {
+        int value = 1;
+
+        {
+            test_override override(catcher);
+            SNITCH_CHECK(value ^ 0);
+        }
+
+        CHECK(value == 1);
+        CHECK_EXPR_SUCCESS(catcher);
+    }
+
+    SECTION("integer expression & pass") {
+        int value = 1;
+
+        {
+            test_override override(catcher);
+            SNITCH_CHECK(value & 1);
+        }
+
+        CHECK(value == 1);
+        CHECK_EXPR_SUCCESS(catcher);
+    }
+
+    SECTION("integer expression | pass") {
+        int value = 1;
+
+        {
+            test_override override(catcher);
+            SNITCH_CHECK(value | 1);
+        }
+
+        CHECK(value == 1);
+        CHECK_EXPR_SUCCESS(catcher);
+    }
+
     SECTION("integer expression * fail") {
         int         value        = 0;
         std::size_t failure_line = 0u;
@@ -381,18 +417,57 @@ TEST_CASE("check unary", "[test macros]") {
 
         CHECK(value == 1);
         CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(2 % value), got 0"sv);
+    }
 
+    SECTION("integer expression ^ fail") {
+        int         value        = 1;
+        std::size_t failure_line = 0u;
 
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value ^ 1); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value == 1);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value ^ 1), got 0"sv);
+    }
+
+    SECTION("integer expression & fail") {
+        int         value        = 1;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value & 0); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value == 1);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value & 0), got 0"sv);
+    }
+
+    SECTION("integer expression | fail") {
+        int         value        = 0;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value | 0); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value == 0);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value | 0), got 0"sv);
     }
 }
 
 SNITCH_WARNING_POP
 
 TEST_CASE("check binary", "[test macros]") {
-
-
-
-
     event_catcher catcher;
 
     SECTION("integer == pass") {
@@ -580,6 +655,10 @@ TEST_CASE("check binary", "[test macros]") {
         CHECK(value2 == 1);
         CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value1 >= value2), got 0 < 1"sv);
     }
+}
+
+TEST_CASE("check no decomposition", "[test macros]") {
+    event_catcher catcher;
 
     SECTION("spaceship") {
         int         value1       = 1;
@@ -598,7 +677,7 @@ TEST_CASE("check binary", "[test macros]") {
         CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value1 <=> value2 != 0)"sv);
     }
 
-    SECTION("complex expression") {
+    SECTION("with operator &&") {
         int         value1       = 1;
         int         value2       = 1;
         std::size_t failure_line = 0u;
@@ -613,16 +692,160 @@ TEST_CASE("check binary", "[test macros]") {
         CHECK(value1 == 1);
         CHECK(value2 == 1);
         CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value1 == 1 && value2 == 0)"sv);
+    }
 
+    SECTION("with operator ||") {
+        int         value1       = 2;
+        int         value2       = 1;
+        std::size_t failure_line = 0u;
 
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value1 == 1 || value2 == 0); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value1 == 2);
+        CHECK(value2 == 1);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value1 == 1 || value2 == 0)"sv);
+    }
+
+    SECTION("with operator =") {
+        int         value        = 1;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value = 0); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value == 0);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value = 0)"sv);
+    }
+
+    SECTION("with operator +=") {
+        int         value        = 1;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value += -1); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value == 0);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value += -1)"sv);
+    }
+
+    SECTION("with operator -=") {
+        int         value        = 1;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value -= 1); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value == 0);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value -= 1)"sv);
+    }
+
+    SECTION("with operator *=") {
+        int         value        = 1;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value *= 0); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value == 0);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value *= 0)"sv);
+    }
+
+    SECTION("with operator /=") {
+        int         value        = 1;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value /= 10); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value == 0);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value /= 10)"sv);
+    }
+
+    SECTION("with multiple comparisons") {
+        int         value1       = 2;
+        int         value2       = 1;
+        bool        value3       = true;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value1 == value2 == value3); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value1 == 2);
+        CHECK(value2 == 1);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value1 == value2 == value3)"sv);
+    }
+
+    SECTION("with final ^") {
+        int         value1       = 2;
+        int         value2       = 1;
+        bool        value3       = false;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value1 == value2 ^ value3); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value1 == 2);
+        CHECK(value2 == 1);
+        CHECK(value3 == false);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value1 == value2 ^ value3)"sv);
+    }
+
+    SECTION("with two final ^") {
+        int         value1       = 2;
+        int         value2       = 1;
+        bool        value3       = false;
+        bool        value4       = false;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value1 == value2 ^ value3 ^ value4); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value1 == 2);
+        CHECK(value2 == 1);
+        CHECK(value3 == false);
+        CHECK(value4 == false);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value1 == value2 ^ value3 ^ value4)"sv);
     }
 }
 
 TEST_CASE("check false", "[test macros]") {
-
-
-
-
     event_catcher catcher;
 
     SECTION("binary pass") {

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -576,6 +576,9 @@ TEST_CASE("check binary", "[test macros]") {
     }
 }
 
+SNITCH_WARNING_PUSH
+SNITCH_WARNING_DISABLE_PRECEDENCE
+
 TEST_CASE("check no decomposition", "[test macros]") {
     event_catcher catcher;
 
@@ -808,6 +811,8 @@ TEST_CASE("check no decomposition", "[test macros]") {
         CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value1 == value2 ^ value3 ^ value4)"sv);
     }
 }
+
+SNITCH_WARNING_POP
 
 TEST_CASE("check false", "[test macros]") {
     event_catcher catcher;

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -308,42 +308,6 @@ TEST_CASE("check unary", "[test macros]") {
         CHECK_EXPR_SUCCESS(catcher);
     }
 
-    SECTION("integer expression ^ pass") {
-        int value = 1;
-
-        {
-            test_override override(catcher);
-            SNITCH_CHECK(value ^ 0);
-        }
-
-        CHECK(value == 1);
-        CHECK_EXPR_SUCCESS(catcher);
-    }
-
-    SECTION("integer expression & pass") {
-        int value = 1;
-
-        {
-            test_override override(catcher);
-            SNITCH_CHECK(value & 1);
-        }
-
-        CHECK(value == 1);
-        CHECK_EXPR_SUCCESS(catcher);
-    }
-
-    SECTION("integer expression | pass") {
-        int value = 1;
-
-        {
-            test_override override(catcher);
-            SNITCH_CHECK(value | 1);
-        }
-
-        CHECK(value == 1);
-        CHECK_EXPR_SUCCESS(catcher);
-    }
-
     SECTION("integer expression * fail") {
         int         value        = 0;
         std::size_t failure_line = 0u;
@@ -417,51 +381,6 @@ TEST_CASE("check unary", "[test macros]") {
 
         CHECK(value == 1);
         CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(2 % value), got 0"sv);
-    }
-
-    SECTION("integer expression ^ fail") {
-        int         value        = 1;
-        std::size_t failure_line = 0u;
-
-        {
-            test_override override(catcher);
-            // clang-format off
-            SNITCH_CHECK(value ^ 1); failure_line = __LINE__;
-            // clang-format on
-        }
-
-        CHECK(value == 1);
-        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value ^ 1), got 0"sv);
-    }
-
-    SECTION("integer expression & fail") {
-        int         value        = 1;
-        std::size_t failure_line = 0u;
-
-        {
-            test_override override(catcher);
-            // clang-format off
-            SNITCH_CHECK(value & 0); failure_line = __LINE__;
-            // clang-format on
-        }
-
-        CHECK(value == 1);
-        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value & 0), got 0"sv);
-    }
-
-    SECTION("integer expression | fail") {
-        int         value        = 0;
-        std::size_t failure_line = 0u;
-
-        {
-            test_override override(catcher);
-            // clang-format off
-            SNITCH_CHECK(value | 0); failure_line = __LINE__;
-            // clang-format on
-        }
-
-        CHECK(value == 0);
-        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value | 0), got 0"sv);
     }
 }
 
@@ -784,6 +703,51 @@ TEST_CASE("check no decomposition", "[test macros]") {
 
         CHECK(value == 0);
         CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value /= 10)"sv);
+    }
+
+    SECTION("with operator ^") {
+        int         value        = 1;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value ^ 1); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value == 1);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value ^ 1)"sv);
+    }
+
+    SECTION("with operator &") {
+        int         value        = 1;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value & 0); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value == 1);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value & 0)"sv);
+    }
+
+    SECTION("with operator |") {
+        int         value        = 0;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(catcher);
+            // clang-format off
+            SNITCH_CHECK(value | 0); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value == 0);
+        CHECK_EXPR_FAILURE(catcher, failure_line, "CHECK(value | 0)"sv);
     }
 
     SECTION("with multiple comparisons") {

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -72,9 +72,9 @@ struct event_catcher {
     snitch::impl::test_case mock_case{
         .id    = {"mock_test", "[mock_tag]", "mock_type"},
         .func  = nullptr,
-        .state = snitch::impl::test_state::not_run};
+        .state = snitch::impl::test_case_state::not_run};
 
-    snitch::impl::test_run mock_run{.reg = mock_registry, .test = mock_case};
+    snitch::impl::test_state mock_test{.reg = mock_registry, .test = mock_case};
 
     std::optional<event_deep_copy> last_event;
 
@@ -88,11 +88,11 @@ struct event_catcher {
 };
 
 struct test_override {
-    snitch::impl::test_run* previous;
+    snitch::impl::test_state* previous;
 
     explicit test_override(event_catcher& catcher) :
         previous(snitch::impl::try_get_current_test()) {
-        snitch::impl::set_current_test(&catcher.mock_run);
+        snitch::impl::set_current_test(&catcher.mock_test);
     }
 
     ~test_override() {
@@ -119,13 +119,13 @@ struct long_matcher_always_fails {
 
 #define CHECK_EXPR_SUCCESS(CATCHER)                                                                \
     do {                                                                                           \
-        CHECK((CATCHER).mock_run.asserts == 1u);                                                   \
+        CHECK((CATCHER).mock_test.asserts == 1u);                                                  \
         CHECK(!(CATCHER).last_event.has_value());                                                  \
     } while (0)
 
 #define CHECK_EXPR_FAILURE(CATCHER, FAILURE_LINE, MESSAGE)                                         \
     do {                                                                                           \
-        CHECK((CATCHER).mock_run.asserts == 1u);                                                   \
+        CHECK((CATCHER).mock_test.asserts == 1u);                                                  \
         REQUIRE((CATCHER).last_event.has_value());                                                 \
         const auto& event = (CATCHER).last_event.value();                                          \
         CHECK(event.event_type == event_deep_copy::type::assertion_failed);                        \

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -578,6 +578,7 @@ TEST_CASE("check binary", "[test macros]") {
 
 SNITCH_WARNING_PUSH
 SNITCH_WARNING_DISABLE_PRECEDENCE
+SNITCH_WARNING_DISABLE_ASSIGNMENT
 
 TEST_CASE("check no decomposition", "[test macros]") {
     event_catcher catcher;

--- a/tests/runtime_tests/macros.cpp
+++ b/tests/runtime_tests/macros.cpp
@@ -2,7 +2,7 @@
 
 namespace {
 bool test_called = false;
-}
+} // namespace
 
 TEST_CASE("test without tags") {
     CHECK(!test_called);

--- a/tests/runtime_tests/registry.cpp
+++ b/tests/runtime_tests/registry.cpp
@@ -518,7 +518,7 @@ TEST_CASE("run tests", "[registry]") {
                 CHECK(
                     framework.messages ==
                     contains_substring("some tests failed (3 out of 5 test cases, 3 assertions, 1 "
-                                       "test cases skipped)"));
+                                       "test cases skipped"));
             } else {
                 CHECK(framework.get_num_runs() == 5u);
                 CHECK_RUN(false, 5u, 3u, 1u, 3u);
@@ -539,7 +539,7 @@ TEST_CASE("run tests", "[registry]") {
             if (r == reporter::print) {
                 CHECK(
                     framework.messages ==
-                    contains_substring("all tests passed (1 test cases, 0 assertions)"));
+                    contains_substring("all tests passed (1 test cases, 0 assertions"));
             } else {
                 CHECK(framework.get_num_runs() == 1u);
                 CHECK_RUN(true, 1u, 0u, 0u, 0u);
@@ -560,7 +560,7 @@ TEST_CASE("run tests", "[registry]") {
             if (r == reporter::print) {
                 CHECK(
                     framework.messages ==
-                    contains_substring("some tests failed (3 out of 3 test cases, 3 assertions)"));
+                    contains_substring("some tests failed (3 out of 3 test cases, 3 assertions"));
             } else {
                 CHECK(framework.get_num_runs() == 3u);
                 CHECK_RUN(false, 3u, 3u, 0u, 3u);
@@ -582,7 +582,7 @@ TEST_CASE("run tests", "[registry]") {
                 CHECK(
                     framework.messages ==
                     contains_substring("all tests passed (1 test cases, 0 assertions, 1 "
-                                       "test cases skipped)"));
+                                       "test cases skipped"));
             } else {
                 CHECK(framework.get_num_runs() == 1u);
                 CHECK_RUN(true, 1u, 0u, 1u, 0u);
@@ -603,7 +603,7 @@ TEST_CASE("run tests", "[registry]") {
             if (r == reporter::print) {
                 CHECK(
                     framework.messages ==
-                    contains_substring("some tests failed (1 out of 2 test cases, 1 assertions)"));
+                    contains_substring("some tests failed (1 out of 2 test cases, 1 assertions"));
             } else {
                 CHECK(framework.get_num_runs() == 2u);
                 CHECK_RUN(false, 2u, 1u, 0u, 1u);
@@ -624,7 +624,7 @@ TEST_CASE("run tests", "[registry]") {
             if (r == reporter::print) {
                 CHECK(
                     framework.messages ==
-                    contains_substring("all tests passed (2 test cases, 0 assertions)"));
+                    contains_substring("all tests passed (2 test cases, 0 assertions"));
             } else {
                 CHECK(framework.get_num_runs() == 2u);
                 CHECK_RUN(true, 2u, 0u, 0u, 0u);
@@ -637,7 +637,7 @@ TEST_CASE("run tests", "[registry]") {
             if (r == reporter::print) {
                 CHECK(
                     framework.messages ==
-                    contains_substring("all tests passed (2 test cases, 1 assertions)"));
+                    contains_substring("all tests passed (2 test cases, 1 assertions"));
             } else {
                 CHECK(framework.get_num_runs() == 2u);
                 CHECK_RUN(true, 2u, 0u, 0u, 1u);
@@ -650,7 +650,7 @@ TEST_CASE("run tests", "[registry]") {
             if (r == reporter::print) {
                 CHECK(
                     framework.messages ==
-                    contains_substring("some tests failed (1 out of 2 test cases, 1 assertions)"));
+                    contains_substring("some tests failed (1 out of 2 test cases, 1 assertions"));
             } else {
                 CHECK(framework.get_num_runs() == 2u);
                 CHECK_RUN(false, 2u, 1u, 0u, 1u);
@@ -663,7 +663,7 @@ TEST_CASE("run tests", "[registry]") {
             if (r == reporter::print) {
                 CHECK(
                     framework.messages ==
-                    contains_substring("all tests passed (2 test cases, 1 assertions)"));
+                    contains_substring("all tests passed (2 test cases, 1 assertions"));
             } else {
                 CHECK(framework.get_num_runs() == 2u);
                 CHECK_RUN(true, 2u, 0u, 0u, 1u);

--- a/tests/runtime_tests/regressions.cpp
+++ b/tests/runtime_tests/regressions.cpp
@@ -1,0 +1,18 @@
+#include "testing.hpp"
+
+// Checks that we don't get parenthesis warnings from GCC when in template function.
+// https://github.com/catchorg/Catch2/issues/870
+// https://github.com/catchorg/Catch2/issues/565
+// The original issue was a GCC bug, which forced Catch2 to disable the parentheses warning
+// globally. This seems to have been fixed in GCC now.
+namespace {
+template<typename T>
+void template_test_function() {
+    T a = 1, b = 1;
+    CHECK(a == b);
+}
+} // namespace
+
+TEST_CASE("Wparentheses", "[regressions]") {
+    template_test_function<int>();
+}

--- a/tests/runtime_tests/section.cpp
+++ b/tests/runtime_tests/section.cpp
@@ -31,7 +31,7 @@ TEST_CASE("section", "[test macros]") {
         framework.run_test();
         REQUIRE(framework.get_num_failures() == 1u);
         CHECK_SECTIONS("section 1");
-        CHECK_CASE_ASSERTS(false, 1u);
+        CHECK_CASE(snitch::test_case_state::failed, 1u);
     }
 
     SECTION("two sections") {
@@ -49,7 +49,7 @@ TEST_CASE("section", "[test macros]") {
         REQUIRE(framework.get_num_failures() == 2u);
         CHECK_SECTIONS_FOR_FAILURE(0u, "section 1");
         CHECK_SECTIONS_FOR_FAILURE(1u, "section 2");
-        CHECK_CASE_ASSERTS(false, 2u);
+        CHECK_CASE(snitch::test_case_state::failed, 2u);
     }
 
     SECTION("nested sections") {
@@ -67,7 +67,7 @@ TEST_CASE("section", "[test macros]") {
         REQUIRE(framework.get_num_failures() == 2u);
         CHECK_SECTIONS_FOR_FAILURE(0u, "section 1");
         CHECK_SECTIONS_FOR_FAILURE(1u, "section 1", "section 1.1");
-        CHECK_CASE_ASSERTS(false, 2u);
+        CHECK_CASE(snitch::test_case_state::failed, 2u);
     }
 
     SECTION("nested sections abort early") {
@@ -87,7 +87,7 @@ TEST_CASE("section", "[test macros]") {
 
         REQUIRE(framework.get_num_failures() == 1u);
         CHECK_SECTIONS("section 1");
-        CHECK_CASE_ASSERTS(false, 1u);
+        CHECK_CASE(snitch::test_case_state::failed, 1u);
     }
 
     SECTION("nested sections std::exception throw") {
@@ -107,7 +107,7 @@ TEST_CASE("section", "[test macros]") {
 
         REQUIRE(framework.get_num_failures() == 1u);
         CHECK_NO_SECTION;
-        CHECK_CASE_ASSERTS(false, 0u);
+        CHECK_CASE(snitch::test_case_state::failed, 0u);
     }
 
     SECTION("nested sections unknown exception throw") {
@@ -127,7 +127,7 @@ TEST_CASE("section", "[test macros]") {
 
         REQUIRE(framework.get_num_failures() == 1u);
         CHECK_NO_SECTION;
-        CHECK_CASE_ASSERTS(false, 0u);
+        CHECK_CASE(snitch::test_case_state::failed, 0u);
     }
 
     SECTION("nested sections varying depth") {
@@ -167,7 +167,7 @@ TEST_CASE("section", "[test macros]") {
         CHECK_SECTIONS_FOR_FAILURE(2u, "section 2", "section 2.1");
         CHECK_SECTIONS_FOR_FAILURE(3u, "section 2");
         CHECK_SECTIONS_FOR_FAILURE(4u, "section 3");
-        CHECK_CASE_ASSERTS(false, 11u);
+        CHECK_CASE(snitch::test_case_state::failed, 11u);
     }
 
     SECTION("one section in a loop") {
@@ -189,7 +189,7 @@ TEST_CASE("section", "[test macros]") {
         CHECK_SECTIONS_FOR_FAILURE(2u, "section 1");
         CHECK_SECTIONS_FOR_FAILURE(3u, "section 1");
         CHECK_SECTIONS_FOR_FAILURE(4u, "section 1");
-        CHECK_CASE_ASSERTS(false, 30u);
+        CHECK_CASE(snitch::test_case_state::failed, 30u);
     }
 
     SECTION("two sections in a loop") {
@@ -215,7 +215,7 @@ TEST_CASE("section", "[test macros]") {
         CHECK_SECTIONS_FOR_FAILURE(2u, "section 2");
         CHECK_SECTIONS_FOR_FAILURE(3u, "section 1");
         CHECK_SECTIONS_FOR_FAILURE(4u, "section 2");
-        CHECK_CASE_ASSERTS(false, 60u);
+        CHECK_CASE(snitch::test_case_state::failed, 60u);
     }
 }
 

--- a/tests/runtime_tests/section.cpp
+++ b/tests/runtime_tests/section.cpp
@@ -31,6 +31,7 @@ TEST_CASE("section", "[test macros]") {
         framework.run_test();
         REQUIRE(framework.get_num_failures() == 1u);
         CHECK_SECTIONS("section 1");
+        CHECK_CASE_ASSERTS(false, 1u);
     }
 
     SECTION("two sections") {
@@ -48,6 +49,7 @@ TEST_CASE("section", "[test macros]") {
         REQUIRE(framework.get_num_failures() == 2u);
         CHECK_SECTIONS_FOR_FAILURE(0u, "section 1");
         CHECK_SECTIONS_FOR_FAILURE(1u, "section 2");
+        CHECK_CASE_ASSERTS(false, 2u);
     }
 
     SECTION("nested sections") {
@@ -65,6 +67,7 @@ TEST_CASE("section", "[test macros]") {
         REQUIRE(framework.get_num_failures() == 2u);
         CHECK_SECTIONS_FOR_FAILURE(0u, "section 1");
         CHECK_SECTIONS_FOR_FAILURE(1u, "section 1", "section 1.1");
+        CHECK_CASE_ASSERTS(false, 2u);
     }
 
     SECTION("nested sections abort early") {
@@ -84,6 +87,7 @@ TEST_CASE("section", "[test macros]") {
 
         REQUIRE(framework.get_num_failures() == 1u);
         CHECK_SECTIONS("section 1");
+        CHECK_CASE_ASSERTS(false, 1u);
     }
 
     SECTION("nested sections std::exception throw") {
@@ -103,6 +107,7 @@ TEST_CASE("section", "[test macros]") {
 
         REQUIRE(framework.get_num_failures() == 1u);
         CHECK_NO_SECTION;
+        CHECK_CASE_ASSERTS(false, 0u);
     }
 
     SECTION("nested sections unknown exception throw") {
@@ -122,12 +127,16 @@ TEST_CASE("section", "[test macros]") {
 
         REQUIRE(framework.get_num_failures() == 1u);
         CHECK_NO_SECTION;
+        CHECK_CASE_ASSERTS(false, 0u);
     }
 
     SECTION("nested sections varying depth") {
         framework.test_case.func = []() {
+            SNITCH_CHECK(true);
+
             SNITCH_SECTION("section 1") {
-                SNITCH_SECTION("section 1.1") {}
+                SNITCH_SECTION("section 1.1") {
+                }
                 SNITCH_SECTION("section 1.2") {
                     SNITCH_FAIL_CHECK("trigger");
                 }
@@ -136,7 +145,8 @@ TEST_CASE("section", "[test macros]") {
                         SNITCH_FAIL_CHECK("trigger");
                     }
                 }
-                SNITCH_SECTION("section 1.3") {}
+                SNITCH_SECTION("section 1.3") {
+                }
             }
             SNITCH_SECTION("section 2") {
                 SNITCH_SECTION("section 2.1") {
@@ -157,11 +167,14 @@ TEST_CASE("section", "[test macros]") {
         CHECK_SECTIONS_FOR_FAILURE(2u, "section 2", "section 2.1");
         CHECK_SECTIONS_FOR_FAILURE(3u, "section 2");
         CHECK_SECTIONS_FOR_FAILURE(4u, "section 3");
+        CHECK_CASE_ASSERTS(false, 11u);
     }
 
     SECTION("one section in a loop") {
         framework.test_case.func = []() {
             for (std::size_t i = 0u; i < 5u; ++i) {
+                SNITCH_CHECK(i <= 10u);
+
                 SNITCH_SECTION("section 1") {
                     SNITCH_FAIL_CHECK("trigger");
                 }
@@ -176,14 +189,18 @@ TEST_CASE("section", "[test macros]") {
         CHECK_SECTIONS_FOR_FAILURE(2u, "section 1");
         CHECK_SECTIONS_FOR_FAILURE(3u, "section 1");
         CHECK_SECTIONS_FOR_FAILURE(4u, "section 1");
+        CHECK_CASE_ASSERTS(false, 30u);
     }
 
     SECTION("two sections in a loop") {
         framework.test_case.func = []() {
             for (std::size_t i = 0u; i < 5u; ++i) {
+                SNITCH_CHECK(i <= 10u);
+
                 SNITCH_SECTION("section 1") {
                     SNITCH_CHECK(i % 2u == 0u);
                 }
+
                 SNITCH_SECTION("section 2") {
                     SNITCH_CHECK(i % 2u == 1u);
                 }
@@ -198,8 +215,9 @@ TEST_CASE("section", "[test macros]") {
         CHECK_SECTIONS_FOR_FAILURE(2u, "section 2");
         CHECK_SECTIONS_FOR_FAILURE(3u, "section 1");
         CHECK_SECTIONS_FOR_FAILURE(4u, "section 2");
+        CHECK_CASE_ASSERTS(false, 60u);
     }
-};
+}
 
 SNITCH_WARNING_POP
 
@@ -246,4 +264,4 @@ TEST_CASE("section readme example", "[test macros]") {
     framework.run_test();
 
     CHECK(events == "S|1|E|S|2|E|S|3|3.1|E|S|3|3.2|E"sv);
-};
+}

--- a/tests/runtime_tests/small_string.cpp
+++ b/tests/runtime_tests/small_string.cpp
@@ -368,12 +368,8 @@ TEMPLATE_TEST_CASE("small string", "[utility]", string_type, span_type, view_typ
 }
 
 TEST_CASE("constexpr small string", "[utility]") {
-    constexpr std::size_t max_length = 5u;
-
-    using TestType = snitch::small_string<max_length>;
-
     SECTION("from string view") {
-        constexpr TestType v = "abc"sv;
+        constexpr string_type v = "abc"sv;
 
         CHECK(v.size() == 3u);
         CHECK(!v.empty());
@@ -388,8 +384,8 @@ TEST_CASE("constexpr small string", "[utility]") {
     }
 
     SECTION("from immediate lambda") {
-        constexpr TestType v = []() {
-            TestType v;
+        constexpr string_type v = []() {
+            string_type v;
             v.push_back('a');
             v.push_back('b');
             v.push_back('c');

--- a/tests/runtime_tests/small_string.cpp
+++ b/tests/runtime_tests/small_string.cpp
@@ -367,50 +367,49 @@ TEMPLATE_TEST_CASE("small string", "[utility]", string_type, span_type, view_typ
     }
 }
 
-// This requires fixing https://github.com/cschreib/snitch/issues/17
-// TEST_CASE("constexpr small string", "[utility]") {
-//     constexpr std::size_t max_length = 5u;
+TEST_CASE("constexpr small string", "[utility]") {
+    constexpr std::size_t max_length = 5u;
 
-//     using TestType = snitch::small_string<max_length>;
+    using TestType = snitch::small_string<max_length>;
 
-//     SECTION("from string view") {
-//         constexpr TestType v = "abc"sv;
+    SECTION("from string view") {
+        constexpr TestType v = "abc"sv;
 
-//         CHECK(v.size() == 3u);
-//         CHECK(!v.empty());
-//         CHECK(v.capacity() == max_length);
-//         CHECK(v.available() == max_length - 3u);
-//         CHECK(v.end() == v.begin() + 3u);
-//         CHECK(v.cend() == v.cbegin() + 3u);
+        CHECK(v.size() == 3u);
+        CHECK(!v.empty());
+        CHECK(v.capacity() == max_length);
+        CHECK(v.available() == max_length - 3u);
+        CHECK(v.end() == v.begin() + 3u);
+        CHECK(v.cend() == v.cbegin() + 3u);
 
-//         CHECK(v[0] == 'a');
-//         CHECK(v[1] == 'b');
-//         CHECK(v[2] == 'c');
-//     }
+        CHECK(v[0] == 'a');
+        CHECK(v[1] == 'b');
+        CHECK(v[2] == 'c');
+    }
 
-//     SECTION("from immediate lambda") {
-//         constexpr TestType v = []() {
-//             TestType v;
-//             v.push_back('a');
-//             v.push_back('b');
-//             v.push_back('c');
-//             v.push_back('d');
-//             v.pop_back();
-//             v.push_back('e');
-//             v.grow(1u);
-//             v.resize(3u);
-//             return v;
-//         }();
+    SECTION("from immediate lambda") {
+        constexpr TestType v = []() {
+            TestType v;
+            v.push_back('a');
+            v.push_back('b');
+            v.push_back('c');
+            v.push_back('d');
+            v.pop_back();
+            v.push_back('e');
+            v.grow(1u);
+            v.resize(3u);
+            return v;
+        }();
 
-//         CHECK(v.size() == 3u);
-//         CHECK(!v.empty());
-//         CHECK(v.capacity() == max_length);
-//         CHECK(v.available() == max_length - 3u);
-//         CHECK(v.end() = v.begin() + 3u);
-//         CHECK(v.cend() = v.cbegin() + 3u);
+        CHECK(v.size() == 3u);
+        CHECK(!v.empty());
+        CHECK(v.capacity() == max_length);
+        CHECK(v.available() == max_length - 3u);
+        CHECK(v.end() == v.begin() + 3u);
+        CHECK(v.cend() == v.cbegin() + 3u);
 
-//         CHECK(v[0] == 'a');
-//         CHECK(v[1] == 'b');
-//         CHECK(v[2] == 'c');
-//     }
-// };
+        CHECK(v[0] == 'a');
+        CHECK(v[1] == 'b');
+        CHECK(v[2] == 'c');
+    }
+}

--- a/tests/runtime_tests/small_vector.cpp
+++ b/tests/runtime_tests/small_vector.cpp
@@ -442,48 +442,47 @@ TEST_CASE("constexpr small vector test_struct", "[utility]") {
     }
 }
 
-// This requires fixing https://github.com/cschreib/snitch/issues/17
-// TEST_CASE("constexpr small vector int", "[utility]") {
-//     using TestType = snitch::small_vector<int, max_test_elements>;
+TEST_CASE("constexpr small vector int", "[utility]") {
+    using TestType = snitch::small_vector<int, max_test_elements>;
 
-//     SECTION("from initializer list") {
-//         constexpr TestType v = {1, 2, 5};
+    SECTION("from initializer list") {
+        constexpr TestType v = {1, 2, 5};
 
-//         CHECK(v.size() == 3u);
-//         CHECK(!v.empty());
-//         CHECK(v.capacity() == max_test_elements);
-//         CHECK(v.available() == max_test_elements - 3u);
-//         CHECK(v.end() == v.begin() + 3u);
-//         CHECK(v.cend() == v.cbegin() + 3u);
+        CHECK(v.size() == 3u);
+        CHECK(!v.empty());
+        CHECK(v.capacity() == max_test_elements);
+        CHECK(v.available() == max_test_elements - 3u);
+        CHECK(v.end() == v.begin() + 3u);
+        CHECK(v.cend() == v.cbegin() + 3u);
 
-//         CHECK(v[0] == 1);
-//         CHECK(v[1] == 2);
-//         CHECK(v[2] == 3);
-//     }
+        CHECK(v[0] == 1);
+        CHECK(v[1] == 2);
+        CHECK(v[2] == 5);
+    }
 
-//     SECTION("from immediate lambda") {
-//         constexpr TestType v = []() {
-//             TestType v;
-//             v.push_back(1);
-//             v.push_back(2);
-//             v.push_back(5);
-//             v.push_back(6);
-//             v.pop_back();
-//             v.push_back(7);
-//             v.grow(1u);
-//             v.resize(3u);
-//             return v;
-//         }();
+    SECTION("from immediate lambda") {
+        constexpr TestType v = []() {
+            TestType v;
+            v.push_back(1);
+            v.push_back(2);
+            v.push_back(5);
+            v.push_back(6);
+            v.pop_back();
+            v.push_back(7);
+            v.grow(1u);
+            v.resize(3u);
+            return v;
+        }();
 
-//         CHECK(v.size() == 3u);
-//         CHECK(!v.empty());
-//         CHECK(v.capacity() == max_test_elements);
-//         CHECK(v.available() == max_test_elements - 3u);
-//         CHECK(v.end() == v.begin() + 3u);
-//         CHECK(v.cend() == v.cbegin() + 3u);
+        CHECK(v.size() == 3u);
+        CHECK(!v.empty());
+        CHECK(v.capacity() == max_test_elements);
+        CHECK(v.available() == max_test_elements - 3u);
+        CHECK(v.end() == v.begin() + 3u);
+        CHECK(v.cend() == v.cbegin() + 3u);
 
-//         CHECK(v[0] == 1);
-//         CHECK(v[1] == 2);
-//         CHECK(v[2] == 5);
-//     }
-// };
+        CHECK(v[0] == 1);
+        CHECK(v[1] == 2);
+        CHECK(v[2] == 5);
+    }
+}

--- a/tests/testing.hpp
+++ b/tests/testing.hpp
@@ -43,17 +43,21 @@ struct filldata<T*> {
 #    define SNITCH_WARNING_DISABLE_UNREACHABLE
 #    define SNITCH_WARNING_DISABLE_INT_BOOLEAN
 #    define SNITCH_WARNING_DISABLE_PRECEDENCE
+#    define SNITCH_WARNING_DISABLE_ASSIGNMENT
 #elif defined(__GNUC__)
 #    define SNITCH_WARNING_DISABLE_UNREACHABLE
 #    define SNITCH_WARNING_DISABLE_INT_BOOLEAN                                                     \
         _Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")
 #    define SNITCH_WARNING_DISABLE_PRECEDENCE
+#    define SNITCH_WARNING_DISABLE_ASSIGNMENT
 #elif defined(_MSC_VER)
 #    define SNITCH_WARNING_DISABLE_UNREACHABLE _Pragma("warning(disable: 4702)")
 #    define SNITCH_WARNING_DISABLE_INT_BOOLEAN
 #    define SNITCH_WARNING_DISABLE_PRECEDENCE _Pragma("warning(disable: 4554)")
+#    define SNITCH_WARNING_DISABLE_ASSIGNMENT _Pragma("warning(disable: 4706)")
 #else
 #    define SNITCH_WARNING_DISABLE_UNREACHABLE
 #    define SNITCH_WARNING_DISABLE_INT_BOOLEAN
 #    define SNITCH_WARNING_DISABLE_PRECEDENCE
+#    define SNITCH_WARNING_DISABLE_ASSIGNMENT
 #endif

--- a/tests/testing.hpp
+++ b/tests/testing.hpp
@@ -42,14 +42,18 @@ struct filldata<T*> {
 #if defined(__clang__)
 #    define SNITCH_WARNING_DISABLE_UNREACHABLE
 #    define SNITCH_WARNING_DISABLE_INT_BOOLEAN
+#    define SNITCH_WARNING_DISABLE_PRECEDENCE
 #elif defined(__GNUC__)
 #    define SNITCH_WARNING_DISABLE_UNREACHABLE
 #    define SNITCH_WARNING_DISABLE_INT_BOOLEAN                                                     \
         _Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")
+#    define SNITCH_WARNING_DISABLE_PRECEDENCE
 #elif defined(_MSC_VER)
 #    define SNITCH_WARNING_DISABLE_UNREACHABLE _Pragma("warning(disable: 4702)")
 #    define SNITCH_WARNING_DISABLE_INT_BOOLEAN
+#    define SNITCH_WARNING_DISABLE_PRECEDENCE _Pragma("warning(disable: 4554)")
 #else
 #    define SNITCH_WARNING_DISABLE_UNREACHABLE
 #    define SNITCH_WARNING_DISABLE_INT_BOOLEAN
+#    define SNITCH_WARNING_DISABLE_PRECEDENCE
 #endif

--- a/tests/testing_event.cpp
+++ b/tests/testing_event.cpp
@@ -85,7 +85,7 @@ event_deep_copy deep_copy(const snitch::event::data& e) {
                 event_deep_copy c;
                 c.event_type = event_deep_copy::type::test_case_ended;
                 copy_test_case_id(c, s);
-                c.test_case_success         = s.success;
+                c.test_case_state           = s.state;
                 c.test_case_assertion_count = s.assertion_count;
                 return c;
             },

--- a/tests/testing_event.cpp
+++ b/tests/testing_event.cpp
@@ -85,6 +85,8 @@ event_deep_copy deep_copy(const snitch::event::data& e) {
                 event_deep_copy c;
                 c.event_type = event_deep_copy::type::test_case_ended;
                 copy_test_case_id(c, s);
+                c.test_case_success         = s.success;
+                c.test_case_assertion_count = s.assertion_count;
                 return c;
             },
             [](const snitch::event::test_run_started& s) {

--- a/tests/testing_event.hpp
+++ b/tests/testing_event.hpp
@@ -47,7 +47,7 @@ struct mock_framework {
     snitch::impl::test_case test_case{
         .id    = {"mock_test", "[mock_tag]", "mock_type"},
         .func  = nullptr,
-        .state = snitch::impl::test_state::not_run};
+        .state = snitch::impl::test_case_state::not_run};
 
     snitch::small_vector<event_deep_copy, 16> events;
     snitch::small_string<4086>                messages;

--- a/tests/testing_event.hpp
+++ b/tests/testing_event.hpp
@@ -166,3 +166,12 @@ struct cli_input {
         CHECK(end.test_run_skip_count == SKIP_COUNT);                                              \
         CHECK(end.test_run_assertion_count == ASSERT_COUNT);                                       \
     } while (0)
+
+#define CHECK_CASE_ASSERTS(SUCCESS, ASSERT_COUNT)                                                  \
+    do {                                                                                           \
+        REQUIRE(framework.events.size() >= 2u);                                                    \
+        auto end = framework.events.back();                                                        \
+        REQUIRE(end.event_type == event_deep_copy::type::test_case_ended);                         \
+        CHECK(end.test_case_success == SUCCESS);                                                   \
+        CHECK(end.test_case_assertion_count == ASSERT_COUNT);                                      \
+    } while (0)

--- a/tests/testing_event.hpp
+++ b/tests/testing_event.hpp
@@ -21,8 +21,8 @@ struct event_deep_copy {
     std::size_t                                        test_run_skip_count      = 0;
     std::size_t                                        test_run_assertion_count = 0;
 
-    bool        test_case_success         = false;
-    std::size_t test_case_assertion_count = 0;
+    snitch::test_case_state test_case_state           = snitch::test_case_state::success;
+    std::size_t             test_case_assertion_count = 0;
 
     snitch::small_string<snitch::max_test_name_length> test_id_name;
     snitch::small_string<snitch::max_test_name_length> test_id_tags;
@@ -167,11 +167,11 @@ struct cli_input {
         CHECK(end.test_run_assertion_count == ASSERT_COUNT);                                       \
     } while (0)
 
-#define CHECK_CASE_ASSERTS(SUCCESS, ASSERT_COUNT)                                                  \
+#define CHECK_CASE(STATE, ASSERT_COUNT)                                                            \
     do {                                                                                           \
         REQUIRE(framework.events.size() >= 2u);                                                    \
         auto end = framework.events.back();                                                        \
         REQUIRE(end.event_type == event_deep_copy::type::test_case_ended);                         \
-        CHECK(end.test_case_success == SUCCESS);                                                   \
+        CHECK(end.test_case_state == STATE);                                                       \
         CHECK(end.test_case_assertion_count == ASSERT_COUNT);                                      \
     } while (0)

--- a/tests/testing_event.hpp
+++ b/tests/testing_event.hpp
@@ -21,6 +21,9 @@ struct event_deep_copy {
     std::size_t                                        test_run_skip_count      = 0;
     std::size_t                                        test_run_assertion_count = 0;
 
+    bool        test_case_success         = false;
+    std::size_t test_case_assertion_count = 0;
+
     snitch::small_string<snitch::max_test_name_length> test_id_name;
     snitch::small_string<snitch::max_test_name_length> test_id_tags;
     snitch::small_string<snitch::max_test_name_length> test_id_type;


### PR DESCRIPTION
This PR does the following:
 - Add support for using `REQUIRE()`/`CHECK()` macros on expressions containing bitwise operators (`&`, `|`, `^`), and  assignments (`=`, `+=`, etc.).
 - Add missing information to the test events (success/failure/skipped flag and assertion count for `test_case_ended`, and duration for `test_run_ended`).
 - Enable tests for using `small_string` and `small_vector` in `constexpr` context.
 - Some internal refactoring to use clearer names.