### PR TITLE
Added support for fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The goal of _snitch_ is to be a simple, cheap, non-invasive, and user-friendly t
 - [Documentation](#documentation)
     - [Detailed comparison with _Catch2_](#detailed-comparison-with-catch2)
     - [Test case macros](#test-case-macros)
+        - [Standalone test cases](#standalone-test-cases)
+        - [Test cases with fixtures](#test-cases-with-fixtures)
     - [Test check macros](#test-check-macros)
     - [Tags](#tags)
     - [Matchers](#matchers)
@@ -49,8 +51,7 @@ If you need features that are not in the list above, please use _Catch2_ or _doc
 
 Notable current limitations:
 
- - No fixtures, or set-up/tear-down helpers. `SECTION()` can be used to share set-up/tear-down logic instead.
- - No multi-threaded test execution.
+ - No multi-threaded test execution yet; the code is thread-friendly, this is just not implemented.
 
 
 ## Example
@@ -206,6 +207,8 @@ See [the dedicated page in the docs folder](doc/comparison_catch2.md).
 
 ### Test case macros
 
+#### Standalone test cases
+
 `TEST_CASE(NAME, TAGS) { /* test body */ }`
 
 This must be called at namespace, global, or class scope; not inside a function or another test case. This defines a new test case of name `NAME`. `NAME` must be a string literal, and may contain any character, up to a maximum length configured by `SNITCH_MAX_TEST_NAME_LENGTH` (default is `1024`). This name will be used to display test reports, and can be used to filter the tests. It is not required to be a unique name. `TAGS` specify which tag(s) are associated with this test case. This must be a string literal with the same limitations as `NAME`. See the [Tags](#tags) section for more information on tags. Finally, `test body` is the body of your test case. Within this scope, you can use the test macros listed [below](#test-check-macros).
@@ -219,6 +222,23 @@ This is similar to `TEST_CASE`, except that it declares a new test case for each
 `TEMPLATE_LIST_TEST_CASE(NAME, TAGS, TYPES) { /* test code for TestType */ }`
 
 This is equivalent to `TEMPLATE_TEST_CASE`, except that `TYPES` must be a template type list of the form `T<Types...>`, for example `snitch::type_list<Types...>` or `std::tuple<Types...>`. This type list can be declared once and reused for multiple test cases.
+
+
+#### Test cases with fixtures
+
+`TEST_CASE_METHOD(FIXTURE, NAME, TAGS) { /* test body */ }`
+
+This is similar to `TEST_CASE`, except that the test body is interpreted "as if" it was a member function of a class deriving from the `FIXTURE` class. This means the test body has access to public and protected members of `FIXTURE`, but not to private members. Each time the test is executed, a new instance of `FIXTURE` is created, the test body is run on this temporary instance, and finally the instance is destroyed; the instance is not shared between tests.
+
+
+`TEMPLATE_TEST_CASE_METHOD(NAME, TAGS, TYPES...) { /* test code for TestType */ }`
+
+This is similar to `TEST_CASE_METHOD`, except that it declares a new test case for each of the types listed in `TYPES...`. Within the test body, the current type can be accessed as `TestType`. If you tend to reuse the same list of types for multiple test cases, then `TEMPLATE_LIST_TEST_CASE_METHOD()` is recommended instead.
+
+
+`TEMPLATE_LIST_TEST_CASE_METHOD(NAME, TAGS, TYPES) { /* test code for TestType */ }`
+
+This is equivalent to `TEMPLATE_TEST_CASE_METHOD`, except that `TYPES` must be a template type list of the form `T<Types...>`, for example `snitch::type_list<Types...>` or `std::tuple<Types...>`. This type list can be declared once and reused for multiple test cases.
 
 
 ### Test check macros

--- a/doc/comparison_catch2.md
+++ b/doc/comparison_catch2.md
@@ -3,24 +3,25 @@
 | Feature in _Catch2_                                 | In _snitch_   | On roadmap   |
 | ----------------------------------------------------| ------------- | ------------ |
 | **Test cases**                                      |               |              |
-| - `TEST_CASE`                                       | Yes (1)       | Done         |
+| - `TEST_CASE`                                       | Yes           | Done         |
 | - `TEMPLATE_TEST_CASE`                              | Yes           | Done         |
 | - `TEMPLATE_LIST_TEST_CASE`                         | Yes           | Done         |
 | - `TEMPLATE_PRODUCT_TEST_CASE`                      | No            | Maybe        |
 | - `TEMPLATE_TEST_CASE_SIG`                          | No            | Maybe        |
 | - `TEMPLATE_PRODUCT_TEST_CASE_SIG`                  | No            | Maybe        |
-| - `METHOD_AS_TEST_CASE`                             | No            | Unlikely     |
-| - `REGISTER_TEST_CASE`                              | No            | Unlikely     |
-| - `TEST_CASE_METHOD`                                | No            | Unlikely     |
-| - `TEMPLATE_TEST_CASE_METHOD_SIG`                   | No            | Unlikely     |
-| - `TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG`           | No            | Unlikely     |
-| - `TEMPLATE_LIST_TEST_CASE_METHOD`                  | No            | Unlikely     |
+| - `TEST_CASE_METHOD`                                | Yes           | Done         |
+| - `TEMPLATE_TEST_CASE_METHOD`                       | Yes           | Done         |
+| - `TEMPLATE_LIST_TEST_CASE_METHOD`                  | Yes           | Done         |
+| - `TEMPLATE_TEST_CASE_METHOD_SIG`                   | No            | Maybe        |
+| - `TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG`           | No            | Maybe        |
+| - `METHOD_AS_TEST_CASE`                             | No            | No           |
+| - `REGISTER_TEST_CASE`                              | No            | No           |
 | **Tags**                                            |               |              |
-| - Special tags                                      | Yes (2)       | Done         |
+| - Special tags                                      | Yes (1)       | Done         |
 | - `REGISTER_TAG_ALIAS`                              | No            | Maybe        |
 | **Control statements**                              |               |              |
 | - `SECTION`                                         | Yes           | Done         |
-| - `DYNAMIC_SECTION`                                 | No            | Maybe (8)    |
+| - `DYNAMIC_SECTION`                                 | No            | Maybe (7)    |
 | - `CHECKED_IF`                                      | No            | Maybe        |
 | - `CHECKED_ELSE`                                    | No            | Maybe        |
 | **Assertion macros**                                |               |              |
@@ -35,11 +36,11 @@
 | - `STATIC_REQUIRE` / `STATIC_CHECK`                 | No            | Maybe        |
 | - `CHECK_NOFAIL`                                    | No            | Maybe        |
 | - `SUCCEED`                                         | No            | Maybe        |
-| - `FAIL` / `FAIL_CHECK`                             | Yes (3)       | Done         |
+| - `FAIL` / `FAIL_CHECK`                             | Yes (2)       | Done         |
 | - `WARN`                                            | No            | Maybe        |
 | **Logging and context**                             |               |              |
 | - `CAPTURE`                                         | Yes           | Done         |
-| - `INFO`                                            | Yes (3)       | Done         |
+| - `INFO`                                            | Yes (2)       | Done         |
 | - `UNSCOPED_INFO`                                   | No            | Unlikely     |
 | **BDD-style macros**                                |               |              |
 | - `SCENARIO`                                        | No            | No           |
@@ -47,7 +48,7 @@
 | - `WHEN` / `AND_WHEN`                               | No            | No           |
 | - `THEN` / `AND_THEN`                               | No            | No           |
 | **Matchers**                                        |               |              |
-| - Custom matchers                                   | Yes (4)       | Done         |
+| - Custom matchers                                   | Yes (3)       | Done         |
 | - Combining matchers                                | No            | Yes          |
 | **Float matchers**                                  |               |              |
 | - `WithinAbs`                                       | No            | Maybe        |
@@ -57,7 +58,7 @@
 | **String matchers**                                 |               |              |
 | - `StartsWith`                                      | No            | Maybe        |
 | - `EndsWith`                                        | No            | Maybe        |
-| - `ContainsSubstring`                               | Yes (5)       | Done         |
+| - `ContainsSubstring`                               | Yes (4)       | Done         |
 | - `Equals`                                          | No            | Maybe        |
 | - `Matches`                                         | No            | Unlikely     |
 | **Vector matchers**                                 |               |              |
@@ -78,22 +79,21 @@
 | - `AnyTrue`                                         | No            | Maybe        |
 | **Other matchers**                                  |               |              |
 | - `Predicate`                                       | No            | Unlikely     |
-| - `Message`                                         | Yes (6)       | Done         |
+| - `Message`                                         | Yes (5)       | Done         |
 | **Miscelaneous**                                    |               |              |
 | - `BENCHMARK`                                       | No            | No           |
 | - `BENCHMARK_ADVANCED`                              | No            | No           |
 | - `GENERATE`                                        | No            | No           |
-| - `REGISTER_LISTENER`                               | Yes (7)       | Done         |
+| - `REGISTER_LISTENER`                               | Yes (6)       | Done         |
 
 **Notes:**
- 1. Tags are not optional in _snitch_. This may be fixed later, if requested.
- 2. Support for hidden tests (`[.]` or `[.tag]`), `[!mayfail]`, and `[!shouldfail]` only.
- 3. No streaming in _snitch_. For example, `INFO("the number is " << i)` is not supported. Supporting this is not on the roadmap.
- 4. See [the README](README.md#matchers) for differences between _Catch2_ and _snitch_ matchers.
- 5. Spelled `snitch::matchers::contains_substring`.
- 6. Spelled `snitch::matchers::with_what_contains`, and does substring matching (not exact matching). It does not require the exception type to inherit from `std::exception`, just to have a member function `what()` that returns an object convertible to `std::string_view`.
- 7. Supported only in a limited form; use `registry::report_callback` and set it up to call all your event listeners, as needed. Improving this is not on the roadmap.
- 8. If supported, it will not use the streaming syntax.
+ 1. Support for hidden tests (`[.]` or `[.tag]`), `[!mayfail]`, and `[!shouldfail]` only.
+ 2. No streaming in _snitch_. For example, `INFO("the number is " << i)` is not supported. Supporting this is not on the roadmap.
+ 3. See [the README](README.md#matchers) for differences between _Catch2_ and _snitch_ matchers.
+ 4. Spelled `snitch::matchers::contains_substring`.
+ 5. Spelled `snitch::matchers::with_what_contains`, and does substring matching (not exact matching). It does not require the exception type to inherit from `std::exception`, just to have a member function `what()` that returns an object convertible to `std::string_view`.
+ 6. Supported only in a limited form; use `registry::report_callback` and set it up to call all your event listeners, as needed. Improving this is not on the roadmap.
+ 7. If supported, it will not use the streaming syntax.
 
 **Roadmap:**
  - "Yes" is something that we want to eventually support in _snitch_, even if it comes at a cost (at run time or compile time). Contributions are welcome.

--- a/tests/runtime_tests/macros.cpp
+++ b/tests/runtime_tests/macros.cpp
@@ -8,3 +8,49 @@ TEST_CASE("test without tags") {
     CHECK(!test_called);
     test_called = true;
 }
+
+namespace {
+std::size_t test_fixture_instances = 0u;
+
+struct test_fixture {
+    test_fixture() {
+        ++test_fixture_instances;
+    }
+
+    ~test_fixture() {
+        --test_fixture_instances;
+    }
+
+    bool used = false;
+};
+} // namespace
+
+TEST_CASE_METHOD(test_fixture, "test with fixture 1") {
+    CHECK(!used);
+    CHECK(test_fixture_instances == 1u);
+    used = true;
+}
+
+TEST_CASE_METHOD(test_fixture, "test with fixture 2") {
+    CHECK(!used);
+    CHECK(test_fixture_instances == 1u);
+    used = true;
+}
+
+TEST_CASE_METHOD(test_fixture, "test with fixture and section") {
+    SECTION("section 1") {
+        CHECK(!used);
+        CHECK(test_fixture_instances == 1u);
+    }
+
+    SECTION("section 2") {
+        CHECK(!used);
+        CHECK(test_fixture_instances == 1u);
+    }
+
+    used = true;
+}
+
+TEST_CASE("test after test with fixture") {
+    CHECK(test_fixture_instances == 0u);
+}

--- a/tests/testing.hpp
+++ b/tests/testing.hpp
@@ -19,10 +19,11 @@
 // Adjust doctest macros to match the snitch API
 #    define SECTION(name) DOCTEST_SUBCASE(name)
 #    undef TEST_CASE
-#    define TEST_CASE(name, ...) DOCTEST_TEST_CASE(name " " __VA_ARGS__)
+#    define TEST_CASE(name, ...) DOCTEST_TEST_CASE(name)
 #    define TEMPLATE_TEST_CASE(name, tags, ...)                                                    \
         DOCTEST_TEST_CASE_TEMPLATE(tags " " name, TestType, __VA_ARGS__)
 #    define SKIP(message) return
+#    define TEST_CASE_METHOD(fixture, name, ...) DOCTEST_TEST_CASE_FIXTURE(fixture, name)
 
 #    include <ostream>
 


### PR DESCRIPTION
This PR adds macros to support test fixtures, for the more traditional set-up/tear-down layout.