### PR TITLE
Include missing <utility> header

### DIFF
--- a/include/snitch/snitch.hpp
+++ b/include/snitch/snitch.hpp
@@ -13,6 +13,7 @@
 #include <optional> // for cli
 #include <string_view> // for all strings
 #include <type_traits> // for std::is_nothrow_*
+#include <utility> // for std::forward, std::move
 #include <variant> // for events and small_function
 
 // Testing framework configuration.


### PR DESCRIPTION
Otherwise, gcc fails to compile tests/runtime_tests/small_vector.cpp due to the undeclared symbol std::as_const.