### PR TITLE
Fix absolute paths in library and missing tests

### DIFF
--- a/src/snitch.cpp
+++ b/src/snitch.cpp
@@ -921,9 +921,10 @@ test_state registry::run(test_case& test) noexcept {
             // Test aborted, assume its state was already set accordingly.
         } catch (const std::exception& e) {
             report_failure(
-                state, {__FILE__, __LINE__}, "unhandled std::exception caught; message:", e.what());
+                state, {"<snitch internal>", 0},
+                "unhandled std::exception caught; message:", e.what());
         } catch (...) {
-            report_failure(state, {__FILE__, __LINE__}, "unhandled unknown exception caught");
+            report_failure(state, {"<snitch internal>", 0}, "unhandled unknown exception caught");
         }
 #else
         test.func();
@@ -941,7 +942,7 @@ test_state registry::run(test_case& test) noexcept {
     if (state.should_fail) {
         if (state.test.state == impl::test_case_state::success) {
             state.should_fail = false;
-            report_failure(state, {__FILE__, __LINE__}, "expected test to fail, but it passed");
+            report_failure(state, {"<snitch internal>", 0}, "expected test to fail, but it passed");
             state.should_fail = true;
         } else if (state.test.state == impl::test_case_state::failed) {
             state.test.state = impl::test_case_state::success;

--- a/src/snitch.cpp
+++ b/src/snitch.cpp
@@ -922,7 +922,7 @@ test_state registry::run(test_case& test) noexcept {
         } catch (const std::exception& e) {
             report_failure(
                 state, {"<snitch internal>", 0},
-                "unhandled std::exception caught; message:", e.what());
+                "unhandled std::exception caught; message: ", e.what());
         } catch (...) {
             report_failure(state, {"<snitch internal>", 0}, "unhandled unknown exception caught");
         }

--- a/tests/runtime_tests/registry.cpp
+++ b/tests/runtime_tests/registry.cpp
@@ -419,6 +419,71 @@ TEST_CASE("report REQUIRE_THROWS_AS", "[registry]") {
         CHECK(failure.message == contains_substring("there are four lights"));
     }
 }
+
+TEST_CASE("report unhandled std::exception", "[registry]") {
+    mock_framework framework;
+
+    framework.registry.add(
+        {"how many lights", "[tag]"}, []() { throw std::runtime_error("error message"); });
+
+    auto& test = *framework.registry.begin();
+
+    SECTION("default reporter") {
+        framework.setup_print();
+        framework.registry.run(test);
+
+        CHECK(framework.messages == contains_substring("how many lights"));
+        CHECK(framework.messages == contains_substring("<snitch internal>:0"));
+        CHECK(
+            framework.messages ==
+            contains_substring("unhandled std::exception caught; message: error message"));
+    }
+
+    SECTION("custom reporter") {
+        framework.setup_reporter();
+        framework.registry.run(test);
+
+        REQUIRE(framework.get_num_failures() == 1u);
+        auto failure_opt = framework.get_failure_event(0u);
+        REQUIRE(failure_opt.has_value());
+        const auto& failure = failure_opt.value();
+        CHECK_EVENT_TEST_ID(failure, test.id);
+        CHECK_EVENT_LOCATION(failure, "<snitch internal>", 0u);
+        CHECK(
+            failure.message ==
+            contains_substring("unhandled std::exception caught; message: error message"));
+    }
+}
+
+TEST_CASE("report unhandled unknown exception", "[registry]") {
+    mock_framework framework;
+
+    framework.registry.add({"how many lights", "[tag]"}, []() { throw 42; });
+
+    auto& test = *framework.registry.begin();
+
+    SECTION("default reporter") {
+        framework.setup_print();
+        framework.registry.run(test);
+
+        CHECK(framework.messages == contains_substring("how many lights"));
+        CHECK(framework.messages == contains_substring("<snitch internal>:0"));
+        CHECK(framework.messages == contains_substring("unhandled unknown exception caught"));
+    }
+
+    SECTION("custom reporter") {
+        framework.setup_reporter();
+        framework.registry.run(test);
+
+        REQUIRE(framework.get_num_failures() == 1u);
+        auto failure_opt = framework.get_failure_event(0u);
+        REQUIRE(failure_opt.has_value());
+        const auto& failure = failure_opt.value();
+        CHECK_EVENT_TEST_ID(failure, test.id);
+        CHECK_EVENT_LOCATION(failure, "<snitch internal>", 0u);
+        CHECK(failure.message == contains_substring("unhandled unknown exception caught"));
+    }
+}
 #endif
 
 TEST_CASE("report SKIP", "[registry]") {

--- a/tests/runtime_tests/registry.cpp
+++ b/tests/runtime_tests/registry.cpp
@@ -366,6 +366,15 @@ TEST_CASE("report REQUIRE", "[registry]") {
     SECTION("custom reporter") {
         framework.setup_reporter();
         framework.registry.run(test);
+
+        REQUIRE(framework.get_num_failures() == 1u);
+        auto failure_opt = framework.get_failure_event(0u);
+        REQUIRE(failure_opt.has_value());
+        const auto& failure = failure_opt.value();
+        CHECK_EVENT_TEST_ID(failure, test.id);
+        CHECK_EVENT_LOCATION(failure, __FILE__, failure_line);
+        CHECK(failure.message == contains_substring("number_of_lights == 3"));
+        CHECK(failure.message == contains_substring("4 != 3"));
     }
 }
 
@@ -397,6 +406,17 @@ TEST_CASE("report REQUIRE_THROWS_AS", "[registry]") {
     SECTION("custom reporter") {
         framework.setup_reporter();
         framework.registry.run(test);
+
+        REQUIRE(framework.get_num_failures() == 1u);
+        auto failure_opt = framework.get_failure_event(0u);
+        REQUIRE(failure_opt.has_value());
+        const auto& failure = failure_opt.value();
+        CHECK_EVENT_TEST_ID(failure, test.id);
+        CHECK_EVENT_LOCATION(failure, __FILE__, failure_line);
+        CHECK(
+            failure.message ==
+            contains_substring("std::logic_error expected but other std::exception thrown"));
+        CHECK(failure.message == contains_substring("there are four lights"));
     }
 }
 #endif
@@ -424,6 +444,14 @@ TEST_CASE("report SKIP", "[registry]") {
     SECTION("custom reporter") {
         framework.setup_reporter();
         framework.registry.run(test);
+
+        REQUIRE(framework.get_num_skips() == 1u);
+        auto skip_opt = framework.get_skip_event();
+        REQUIRE(skip_opt.has_value());
+        const auto& skip = skip_opt.value();
+        CHECK_EVENT_TEST_ID(skip, test.id);
+        CHECK_EVENT_LOCATION(skip, __FILE__, failure_line);
+        CHECK(skip.message == contains_substring("there are four lights"));
     }
 }
 

--- a/tests/testing_event.cpp
+++ b/tests/testing_event.cpp
@@ -109,6 +109,7 @@ event_deep_copy deep_copy(const snitch::event::data& e) {
             [](const snitch::event::test_case_skipped& s) {
                 event_deep_copy c;
                 c.event_type = event_deep_copy::type::test_case_skipped;
+                copy_test_case_id(c, s);
                 copy_full_location(c, s);
                 return c;
             },


### PR DESCRIPTION
This PR does the following:
 - Closes #62.
 - Closes #74.
 - Added missing test code for custom reporter.