### PR TITLE
Update version number and allow workflows to run on main

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - main
 
 env:
   EM_VERSION: 3.1.35

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -3,6 +3,9 @@ name: CI_meson
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   meson-build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.19)
 
-project(snitch LANGUAGES CXX VERSION 1.0.0)
+project(snitch LANGUAGES CXX VERSION 1.1.0)
 
 # Maximum lengths.
 set(SNITCH_MAX_TEST_CASES        5000 CACHE STRING "Maximum number of test cases in a test application.")

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('snitch', 'cpp',
   default_options: ['cpp_std=c++20', 'default_library=static'],
-  version: '1.0.0'
+  version: '1.1.0'
 )
 
 include_dirs = include_directories('.', 'include')


### PR DESCRIPTION
This PR does the following:
 - Update the version number to 1.1.0
 - Fix the GitHub action workflow triggers, which weren't running when merging to `main`.