### PR TITLE
Implement CHECK_NOTHROW

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,16 @@ This is similar to `REQUIRE_THROWS_AS`, but further checks the content of the ex
 This is similar to `REQUIRE_THROWS_MATCHES`, except that on failure the test case continues. Further failures may be reported in the same test case.
 
 
+`REQUIRE_NOTHROW(EXPR);`
+
+This evaluates the expression `EXPR` inside a `try/catch` block. If an exception is thrown, then this reports a test failure. On failure, the current test case is stopped. Execution then continues with the next test case, if any.
+
+
+`CHECK_NOTHROW(EXPR);`
+
+This is similar to `REQUIRE_NOTHROW`, except that on failure the test case continues. Further failures may be reported in the same test case.
+
+
 #### Miscellaneous
 
 `FAIL(MSG);`

--- a/doc/comparison_catch2.md
+++ b/doc/comparison_catch2.md
@@ -32,7 +32,7 @@
 | - `REQUIRE_THROWS_AS` / `CHECK_THROWS_AS`           | Yes           | Done         |
 | - `REQUIRE_THROWS_WITH` / `CHECK_THROWS_WITH`       | No            | Maybe        |
 | - `REQUIRE_THROWS_MATCHES` / `CHECK_THROWS_MATCHES` | Yes           | Done         |
-| - `REQUIRE_NOTHROW` / `CHECK_NOTHROW`               | No            | Maybe        |
+| - `REQUIRE_NOTHROW` / `CHECK_NOTHROW`               | Yes           | Done         |
 | - `STATIC_REQUIRE` / `STATIC_CHECK`                 | Sort of (8)   | Done         |
 | - `CHECK_NOFAIL`                                    | No            | Maybe        |
 | - `SUCCEED`                                         | No            | Maybe        |

--- a/include/snitch/snitch_macros_exceptions.hpp
+++ b/include/snitch/snitch_macros_exceptions.hpp
@@ -12,7 +12,7 @@
         do {                                                                                       \
             auto& SNITCH_CURRENT_TEST = snitch::impl::get_current_test();                          \
             try {                                                                                  \
-                EXPRESSION;                                                                        \
+                static_cast<void>(EXPRESSION);                                                     \
                 SNITCH_CURRENT_TEST.reg.report_assertion(                                          \
                     false, SNITCH_CURRENT_TEST, {__FILE__, __LINE__},                              \
                     #__VA_ARGS__ " expected but no exception thrown");                             \
@@ -48,7 +48,7 @@
         do {                                                                                       \
             auto& SNITCH_CURRENT_TEST = snitch::impl::get_current_test();                          \
             try {                                                                                  \
-                EXPRESSION;                                                                        \
+                static_cast<void>(EXPRESSION);                                                     \
                 SNITCH_CURRENT_TEST.reg.report_assertion(                                          \
                     false, SNITCH_CURRENT_TEST, {__FILE__, __LINE__},                              \
                     #EXCEPTION " expected but no exception thrown");                               \
@@ -92,12 +92,45 @@
 #    define SNITCH_CHECK_THROWS_MATCHES(EXPRESSION, EXCEPTION, ...)                                \
         SNITCH_REQUIRE_THROWS_MATCHES_IMPL((void)0, EXPRESSION, EXCEPTION, __VA_ARGS__)
 
+#    define SNITCH_REQUIRE_NOTHROW_IMPL(MAYBE_ABORT, ...)                                          \
+        do {                                                                                       \
+            auto& SNITCH_CURRENT_TEST = snitch::impl::get_current_test();                          \
+            try {                                                                                  \
+                static_cast<void>(__VA_ARGS__);                                                    \
+                SNITCH_CURRENT_TEST.reg.report_assertion(                                          \
+                    true, SNITCH_CURRENT_TEST, {__FILE__, __LINE__},                               \
+                    #__VA_ARGS__ " did not throw");                                                \
+            } catch (...) {                                                                        \
+                try {                                                                              \
+                    throw;                                                                         \
+                } catch (const std::exception& e) {                                                \
+                    SNITCH_CURRENT_TEST.reg.report_assertion(                                      \
+                        false, SNITCH_CURRENT_TEST, {__FILE__, __LINE__},                          \
+                        "expected " #__VA_ARGS__                                                   \
+                        " not to throw but it threw a std::exception; message: ",                  \
+                        e.what());                                                                 \
+                } catch (...) {                                                                    \
+                    SNITCH_CURRENT_TEST.reg.report_assertion(                                      \
+                        false, SNITCH_CURRENT_TEST, {__FILE__, __LINE__},                          \
+                        "expected " #__VA_ARGS__                                                   \
+                        " not to throw but it threw an unknown exception");                        \
+                }                                                                                  \
+                MAYBE_ABORT;                                                                       \
+            }                                                                                      \
+        } while (0)
+
+#    define SNITCH_REQUIRE_NOTHROW(...)                                                            \
+        SNITCH_REQUIRE_NOTHROW_IMPL(SNITCH_TESTING_ABORT, __VA_ARGS__)
+#    define SNITCH_CHECK_NOTHROW(...) SNITCH_REQUIRE_NOTHROW_IMPL((void)0, __VA_ARGS__)
+
 // clang-format off
 #if SNITCH_WITH_SHORTHAND_MACROS
 #    define REQUIRE_THROWS_AS(EXPRESSION, ...)                 SNITCH_REQUIRE_THROWS_AS(EXPRESSION, __VA_ARGS__)
 #    define CHECK_THROWS_AS(EXPRESSION, ...)                   SNITCH_CHECK_THROWS_AS(EXPRESSION, __VA_ARGS__)
 #    define REQUIRE_THROWS_MATCHES(EXPRESSION, EXCEPTION, ...) SNITCH_REQUIRE_THROWS_MATCHES(EXPRESSION, EXCEPTION, __VA_ARGS__)
 #    define CHECK_THROWS_MATCHES(EXPRESSION, EXCEPTION, ...)   SNITCH_CHECK_THROWS_MATCHES(EXPRESSION, EXCEPTION, __VA_ARGS__)
+#    define REQUIRE_NOTHROW(...)                               SNITCH_REQUIRE_NOTHROW(__VA_ARGS__)
+#    define CHECK_NOTHROW(...)                                 SNITCH_CHECK_NOTHROW(__VA_ARGS__)
 #endif
 // clang-format on
 


### PR DESCRIPTION
This PR does the following:
 - Implement `REQUIRE_NOTHROW`/`CHECK_NOTHROW` for #96.
 - Fix warnings in `REQUIRE_THROW_*`/`CHECK_THROW_*` when the tested expression returns a value with `[[nodiscard]]`.