### PR TITLE
Fix copy construction of `small_function` and error in tests

### DIFF
--- a/tests/runtime_tests/small_function.cpp
+++ b/tests/runtime_tests/small_function.cpp
@@ -163,5 +163,30 @@ TEMPLATE_TEST_CASE(
             }
             CHECK(test_object_instances <= expected_instances);
         }
+
+        SECTION("from other function") {
+            snitch::small_function<TestType> f1 = &test_class<TestType>::method_static;
+            snitch::small_function<TestType> f2(f1);
+
+            call_function(f1);
+
+            CHECK(function_called);
+            if (!std::is_same_v<R, void>) {
+                CHECK(return_value == 44);
+            }
+            CHECK(test_object_instances <= expected_instances);
+
+            test_object_instances = 0u;
+            return_value          = 0u;
+            function_called       = false;
+
+            call_function(f2);
+
+            CHECK(function_called);
+            if (!std::is_same_v<R, void>) {
+                CHECK(return_value == 44);
+            }
+            CHECK(test_object_instances <= expected_instances);
+        }
     }(type_holder<TestType>{});
 }

--- a/tests/testing_assertions.hpp
+++ b/tests/testing_assertions.hpp
@@ -19,7 +19,7 @@ struct assertion_exception : public std::exception {
 struct assertion_exception_enabler {
     snitch::small_function<void(std::string_view)> prev_handler;
 
-    assertion_exception_enabler() : prev_handler(&snitch::impl::stdout_print) {
+    assertion_exception_enabler() : prev_handler(snitch::assertion_failed_handler) {
         snitch::assertion_failed_handler = [](std::string_view msg) {
             throw assertion_exception(msg);
         };

--- a/tests/testing_event.hpp
+++ b/tests/testing_event.hpp
@@ -75,7 +75,7 @@ struct console_output_catcher {
     snitch::small_string<4086>                              messages = {};
     snitch::small_function<void(std::string_view) noexcept> prev_print;
 
-    console_output_catcher() : prev_print(&snitch::impl::stdout_print) {
+    console_output_catcher() : prev_print(snitch::cli::console_print) {
         snitch::cli::console_print = {*this, snitch::constant<&console_output_catcher::print>{}};
     }
 


### PR DESCRIPTION
This PR does the following:
 - Fixed the copy construction of `small_function`. It would fail as "ambiguous" when passing a non-const reference to a `small_function` object, because of the other constructors. This is now all done properly with concepts. #105 
 - Fixed a test error in `assertion_exception_enabler`, which wasn't resetting the assertion handler correctly.