### PR TITLE
Lower required CMake version for library build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.platform.flags}} -DSNITCH_DO_TEST=1 -DCMAKE_INSTALL_PREFIX=../install
+      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.platform.flags}} -DSNITCH_DO_TEST=1 -DCMAKE_INSTALL_PREFIX=../install --warn-uninitialized -Wdev -Werror=dev
 
     - name: Build
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.platform.flags}} -DSNITCH_DO_TEST=1 -DCMAKE_INSTALL_PREFIX=../install --warn-uninitialized -Wdev -Werror=dev
+      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.platform.flags}} -DSNITCH_DO_TEST=1 -DCMAKE_INSTALL_PREFIX=../install --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev
 
     - name: Build
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,20 +18,20 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Ubuntu GCC,             os: ubuntu-latest,  publish: true,  compiler: g++,     arch: "64", build: "ubuntu64-libstdc++", cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_FLAGS='--coverage'"}
-        - { name: Ubuntu GCC noexcept,    os: ubuntu-latest,  publish: false, compiler: g++,     arch: "64", build: "ubuntu64-libstdc++", cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_FLAGS='-fno-exceptions'"}
-        - { name: Ubuntu GCC notime,      os: ubuntu-latest,  publish: false, compiler: g++,     arch: "64", build: "ubuntu64-libstdc++", cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=g++ -DSNITCH_WITH_TIMINGS=0"}
-        - { name: Ubuntu GCC nounity,     os: ubuntu-latest,  publish: false, compiler: g++,     arch: "64", build: "ubuntu64-libstdc++", cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=g++ -DSNITCH_UNITY_BUILD=0"}
-        - { name: Ubuntu GCC header-only, os: ubuntu-latest,  publish: true,  compiler: g++,     arch: "64", build: "header-only",        cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=g++ -DSNITCH_HEADER_ONLY=1"}
-        - { name: Ubuntu GCC shared,      os: ubuntu-latest,  publish: false, compiler: g++,     arch: "64", build: "ubuntu64-libstdc++", cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=g++ -DBUILD_SHARED_LIBS=1"}
-        - { name: Ubuntu Clang,           os: ubuntu-latest,  publish: true,  compiler: clang++, arch: "64", build: "ubuntu64-libc++",    cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS='-stdlib=libc++'"}
-        - { name: Ubuntu Clang noexcept,  os: ubuntu-latest,  publish: false, compiler: clang++, arch: "64", build: "ubuntu64-libc++",    cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS='-stdlib=libc++ -fno-exceptions'"}
-        - { name: Windows 32,             os: windows-latest, publish: true,  compiler: vs2019,  arch: "32", build: "win32-vs2019",       cmakepp: "",        flags: "-A Win32"}
-        - { name: Windows 64,             os: windows-latest, publish: true,  compiler: vs2019,  arch: "64", build: "win64-vs2019",       cmakepp: "",        flags: "-A x64"}
-        - { name: Windows 64 noexcept,    os: windows-latest, publish: false, compiler: vs2019,  arch: "64", build: "win64-vs2019",       cmakepp: "",        flags: "-A x64"}
-        - { name: Windows 64 shared,      os: windows-latest, publish: false, compiler: vs2019,  arch: "64", build: "win64-vs2019",       cmakepp: "",        flags: "-A x64 -DBUILD_SHARED_LIBS=1"}
-        - { name: MacOS,                  os: macos-latest,   publish: true,  compiler: clang++, arch: "64", build: "osx-libc++",         cmakepp: "",        flags: ""}
-        - { name: MacOS noexcept,         os: macos-latest,   publish: false, compiler: clang++, arch: "64", build: "osx-libc++",         cmakepp: "",        flags: "-DCMAKE_CXX_FLAGS='-fno-exceptions'"}
+        - { name: Ubuntu GCC,             os: ubuntu-latest,  publish: true,  compiler: g++,     arch: "64", build: "ubuntu64-libstdc++", cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_FLAGS='--coverage' --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
+        - { name: Ubuntu GCC noexcept,    os: ubuntu-latest,  publish: false, compiler: g++,     arch: "64", build: "ubuntu64-libstdc++", cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_FLAGS='-fno-exceptions' --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
+        - { name: Ubuntu GCC notime,      os: ubuntu-latest,  publish: false, compiler: g++,     arch: "64", build: "ubuntu64-libstdc++", cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=g++ -DSNITCH_WITH_TIMINGS=0 --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
+        - { name: Ubuntu GCC nounity,     os: ubuntu-latest,  publish: false, compiler: g++,     arch: "64", build: "ubuntu64-libstdc++", cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=g++ -DSNITCH_UNITY_BUILD=0 --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
+        - { name: Ubuntu GCC header-only, os: ubuntu-latest,  publish: true,  compiler: g++,     arch: "64", build: "header-only",        cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=g++ -DSNITCH_HEADER_ONLY=1 --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
+        - { name: Ubuntu GCC shared,      os: ubuntu-latest,  publish: false, compiler: g++,     arch: "64", build: "ubuntu64-libstdc++", cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=g++ -DBUILD_SHARED_LIBS=1 --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
+        - { name: Ubuntu Clang,           os: ubuntu-latest,  publish: true,  compiler: clang++, arch: "64", build: "ubuntu64-libc++",    cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS='-stdlib=libc++' --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
+        - { name: Ubuntu Clang noexcept,  os: ubuntu-latest,  publish: false, compiler: clang++, arch: "64", build: "ubuntu64-libc++",    cmakepp: "",        flags: "-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS='-stdlib=libc++ -fno-exceptions' --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
+        - { name: Windows 32,             os: windows-latest, publish: true,  compiler: vs2019,  arch: "32", build: "win32-vs2019",       cmakepp: "",        flags: "-A Win32 --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
+        - { name: Windows 64,             os: windows-latest, publish: true,  compiler: vs2019,  arch: "64", build: "win64-vs2019",       cmakepp: "",        flags: "-A x64" --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev}
+        - { name: Windows 64 noexcept,    os: windows-latest, publish: false, compiler: vs2019,  arch: "64", build: "win64-vs2019",       cmakepp: "",        flags: "-A x64 --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
+        - { name: Windows 64 shared,      os: windows-latest, publish: false, compiler: vs2019,  arch: "64", build: "win64-vs2019",       cmakepp: "",        flags: "-A x64 -DBUILD_SHARED_LIBS=1 --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
+        - { name: MacOS,                  os: macos-latest,   publish: true,  compiler: clang++, arch: "64", build: "osx-libc++",         cmakepp: "",        flags: "--warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
+        - { name: MacOS noexcept,         os: macos-latest,   publish: false, compiler: clang++, arch: "64", build: "osx-libc++",         cmakepp: "",        flags: "-DCMAKE_CXX_FLAGS='-fno-exceptions' --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev"}
         - { name: WebAssembly,            os: ubuntu-latest,  publish: true,  compiler: em++,    arch: "32", build: "wasm32",             cmakepp: "emcmake", flags: "-DCMAKE_CXX_FLAGS='-s DISABLE_EXCEPTION_CATCHING=0' -DCMAKE_CROSSCOMPILING_EMULATOR=node"}
         - { name: WebAssembly noexcept,   os: ubuntu-latest,  publish: false, compiler: em++,    arch: "32", build: "wasm32",             cmakepp: "emcmake", flags: "-DCMAKE_CXX_FLAGS='-fno-exceptions' -DCMAKE_CROSSCOMPILING_EMULATOR=node"}
         build-type:
@@ -79,7 +79,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.platform.flags}} -DSNITCH_DO_TEST=1 -DCMAKE_INSTALL_PREFIX=../install --warn-uninitialized -Wdev -Wno-deprecated -Werror=dev
+      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.platform.flags}} -DSNITCH_DO_TEST=1 -DCMAKE_INSTALL_PREFIX=../install
 
     - name: Build
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.14)
 
 project(snitch LANGUAGES CXX VERSION 1.2.0)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,12 +48,8 @@ else()
     set(SNITCH_FULL_VERSION "${PROJECT_VERSION}")
 endif()
 
-if (NOT SNITCH_HEADER_ONLY)
-    if (DEFINED BUILD_SHARED_LIBS)
-        set(SNITCH_SHARED_LIBRARY ${BUILD_SHARED_LIBS})
-    else()
-        set(SNITCH_SHARED_LIBRARY 0)
-    endif()
+if (NOT SNITCH_HEADER_ONLY AND DEFINED BUILD_SHARED_LIBS)
+    set(SNITCH_SHARED_LIBRARY ${BUILD_SHARED_LIBS})
 endif()
 
 # Create configure file to store CMake build parameter

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,11 @@ else()
 endif()
 
 if (NOT SNITCH_HEADER_ONLY)
-    set(SNITCH_SHARED_LIBRARY ${BUILD_SHARED_LIBS})
+    if (DEFINED BUILD_SHARED_LIBS)
+        set(SNITCH_SHARED_LIBRARY ${BUILD_SHARED_LIBS})
+    else()
+        set(SNITCH_SHARED_LIBRARY 0)
+    endif()
 endif()
 
 # Create configure file to store CMake build parameter

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.20)
+
 function(add_platform_definitions TARGET)
     target_compile_features(${TARGET} INTERFACE cxx_std_20)
     if (CMAKE_SYSTEM_NAME MATCHES "Emscripten")


### PR DESCRIPTION
This help ConanCenter, which is running 3.18.2. We actually need 3.20, but only for building the tests. For building the library, 3.14 is enough.

Also closes #120 and turns on CMake warnings as errors in CI, so we catch these in the future.