### PR TITLE
Rename `small_function` to `function_ref`

### DIFF
--- a/doc/coding_guidelines.md
+++ b/doc/coding_guidelines.md
@@ -23,7 +23,7 @@ Rationale:
 *snitch* code must not directly or indirectly allocate heap (or "free store") memory while running tests. This means that a number of common C++ STL classes cannot be used (at least not with the default allocator):
  - `std::string`: use `std::string_view` (for constant strings) or `snitch::small_string` (for variable strings) instead.
  - `std::vector`, `std::map`, `std::set`, and their variants: use `std::array` (for fixed size arrays) or `snitch::small_vector` (for variable size arrays) instead.
- - `std::function`: use `snitch::small_function` instead.
+ - `std::function`: use `snitch::function_ref` instead.
  - `std::unique_ptr`, `std::shared_ptr`: use values on the stack, and raw pointers for non-owning references.
 
 Unfortunately, the standard does not generally specify if a function or class allocates heap memory or not. We can make reasonable guesses for simple cases; in particular the following are fine to use:

--- a/include/snitch/snitch_cli.hpp
+++ b/include/snitch/snitch_cli.hpp
@@ -31,7 +31,7 @@ struct input {
     small_vector<argument, max_command_line_args> arguments  = {};
 };
 
-SNITCH_EXPORT extern small_function<void(std::string_view) noexcept> console_print;
+SNITCH_EXPORT extern function_ref<void(std::string_view) noexcept> console_print;
 
 template<typename... Args>
 void print(Args&&... args) noexcept {
@@ -51,9 +51,9 @@ SNITCH_EXPORT std::optional<cli::argument>
               get_positional_argument(const cli::input& args, std::string_view name) noexcept;
 
 SNITCH_EXPORT void for_each_positional_argument(
-    const cli::input&                                      args,
-    std::string_view                                       name,
-    const small_function<void(std::string_view) noexcept>& callback) noexcept;
+    const cli::input&                                    args,
+    std::string_view                                     name,
+    const function_ref<void(std::string_view) noexcept>& callback) noexcept;
 } // namespace snitch::cli
 
 #endif

--- a/include/snitch/snitch_error_handling.hpp
+++ b/include/snitch/snitch_error_handling.hpp
@@ -12,7 +12,7 @@ constexpr std::size_t max_message_length = SNITCH_MAX_MESSAGE_LENGTH;
 
 [[noreturn]] SNITCH_EXPORT void terminate_with(std::string_view msg) noexcept;
 
-SNITCH_EXPORT extern small_function<void(std::string_view)> assertion_failed_handler;
+SNITCH_EXPORT extern function_ref<void(std::string_view)> assertion_failed_handler;
 
 [[noreturn]] SNITCH_EXPORT void assertion_failed(std::string_view msg);
 } // namespace snitch

--- a/include/snitch/snitch_registry.hpp
+++ b/include/snitch/snitch_registry.hpp
@@ -86,12 +86,12 @@ is_filter_match_tags(std::string_view tags, std::string_view filter) noexcept;
 SNITCH_EXPORT [[nodiscard]] filter_result
 is_filter_match_id(std::string_view name, std::string_view tags, std::string_view filter) noexcept;
 
-using print_function  = small_function<void(std::string_view) noexcept>;
-using report_function = small_function<void(const registry&, const event::data&) noexcept>;
+using print_function  = function_ref<void(std::string_view) noexcept>;
+using report_function = function_ref<void(const registry&, const event::data&) noexcept>;
 using configure_report_function =
-    small_function<bool(registry&, std::string_view, std::string_view) noexcept>;
-using initialize_report_function = small_function<void(registry&) noexcept>;
-using finish_report_function     = small_function<void(registry&) noexcept>;
+    function_ref<bool(registry&, std::string_view, std::string_view) noexcept>;
+using initialize_report_function = function_ref<void(registry&) noexcept>;
+using finish_report_function     = function_ref<void(registry&) noexcept>;
 
 struct registered_reporter {
     std::string_view           name;
@@ -270,9 +270,9 @@ public:
 
     // Internal API; do not use.
     SNITCH_EXPORT bool run_selected_tests(
-        std::string_view                                     run_name,
-        const filter_info&                                   filter_strings,
-        const small_function<bool(const test_id&) noexcept>& filter) noexcept;
+        std::string_view                                   run_name,
+        const filter_info&                                 filter_strings,
+        const function_ref<bool(const test_id&) noexcept>& filter) noexcept;
 
     SNITCH_EXPORT bool run_tests(const cli::input& args) noexcept;
 

--- a/src/snitch_cli.cpp
+++ b/src/snitch_cli.cpp
@@ -340,7 +340,7 @@ constexpr const char* program_description =
 }} // namespace snitch::impl
 
 namespace snitch::cli {
-small_function<void(std::string_view) noexcept> console_print = &snitch::impl::stdout_print;
+function_ref<void(std::string_view) noexcept> console_print = &snitch::impl::stdout_print;
 
 void print_help(std::string_view program_name) noexcept {
     print_help(
@@ -391,9 +391,9 @@ get_positional_argument(const cli::input& args, std::string_view name) noexcept 
 }
 
 void for_each_positional_argument(
-    const cli::input&                                      args,
-    std::string_view                                       name,
-    const small_function<void(std::string_view) noexcept>& callback) noexcept {
+    const cli::input&                                    args,
+    std::string_view                                     name,
+    const function_ref<void(std::string_view) noexcept>& callback) noexcept {
 
     auto iter = args.arguments.cbegin();
     while (iter != args.arguments.cend()) {

--- a/src/snitch_error_handling.cpp
+++ b/src/snitch_error_handling.cpp
@@ -17,10 +17,10 @@ namespace snitch {
     assertion_failed_handler(msg);
 
     // The assertion handler should either spin, throw, or terminate, but never return.
-    // We cannot enforce [[noreturn]] through the small_function wrapper. So just in case
+    // We cannot enforce [[noreturn]] through the function_ref wrapper. So just in case
     // it accidentally returns, we terminate.
     std::terminate();
 }
 
-small_function<void(std::string_view)> assertion_failed_handler = &terminate_with;
+function_ref<void(std::string_view)> assertion_failed_handler = &terminate_with;
 } // namespace snitch

--- a/src/snitch_registry.cpp
+++ b/src/snitch_registry.cpp
@@ -583,9 +583,9 @@ impl::test_state registry::run(impl::test_case& test) noexcept {
 }
 
 bool registry::run_selected_tests(
-    std::string_view                                     run_name,
-    const filter_info&                                   filter_strings,
-    const small_function<bool(const test_id&) noexcept>& predicate) noexcept {
+    std::string_view                                   run_name,
+    const filter_info&                                 filter_strings,
+    const function_ref<bool(const test_id&) noexcept>& predicate) noexcept {
 
     if (verbose >= registry::verbosity::normal) {
         report_callback(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,20 +46,20 @@ set(TEST_UTILITY_FILES
 
 set(RUNTIME_TEST_FILES
     ${TEST_UTILITY_FILES}
-    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/type_name.cpp
-    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/small_vector.cpp
-    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/small_string.cpp
-    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/string_utility.cpp
-    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/small_function.cpp
-    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/matchers.cpp
-    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/check.cpp
-    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/skip.cpp
     ${PROJECT_SOURCE_DIR}/tests/runtime_tests/capture.cpp
-    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/section.cpp
+    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/check.cpp
     ${PROJECT_SOURCE_DIR}/tests/runtime_tests/cli.cpp
-    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/registry.cpp
+    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/function_ref.cpp
     ${PROJECT_SOURCE_DIR}/tests/runtime_tests/macros.cpp
-    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/regressions.cpp)
+    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/matchers.cpp
+    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/registry.cpp
+    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/regressions.cpp
+    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/section.cpp
+    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/skip.cpp
+    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/small_string.cpp
+    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/small_vector.cpp
+    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/string_utility.cpp
+    ${PROJECT_SOURCE_DIR}/tests/runtime_tests/type_name.cpp)
 
 set(APPROVAL_TEST_FILES
     ${TEST_UTILITY_FILES}

--- a/tests/runtime_tests/function_ref.cpp
+++ b/tests/runtime_tests/function_ref.cpp
@@ -63,7 +63,7 @@ struct type_holder {};
 // MSVC has a bug that prevents us from writing the test nicely. Work around it.
 // https://developercommunity.visualstudio.com/t/Parameter-pack-argument-is-not-recognize/10191888
 template<typename R, typename... Args>
-void call_function(snitch::small_function<R(Args...) noexcept>& f) {
+void call_function(snitch::function_ref<R(Args...) noexcept>& f) {
     if constexpr (std::is_same_v<R, void>) {
         std::apply(f, std::tuple<Args...>{});
     } else {
@@ -73,7 +73,7 @@ void call_function(snitch::small_function<R(Args...) noexcept>& f) {
 } // namespace
 
 TEMPLATE_TEST_CASE(
-    "small function",
+    "function reference",
     "[utility]",
     function_0_void,
     function_0_int,
@@ -87,7 +87,7 @@ TEMPLATE_TEST_CASE(
         constexpr std::size_t expected_instances = sizeof...(Args) > 0 ? 3u : 0u;
 
         SECTION("from free function") {
-            snitch::small_function<TestType> f = &test_class<TestType>::method_static;
+            snitch::function_ref<TestType> f = &test_class<TestType>::method_static;
 
             call_function(f);
 
@@ -99,8 +99,8 @@ TEMPLATE_TEST_CASE(
         }
 
         SECTION("from non-const member function") {
-            test_class<TestType>             obj;
-            snitch::small_function<TestType> f = {
+            test_class<TestType>           obj;
+            snitch::function_ref<TestType> f = {
                 obj, snitch::constant<&test_class<TestType>::method>{}};
 
             call_function(f);
@@ -113,8 +113,8 @@ TEMPLATE_TEST_CASE(
         }
 
         SECTION("from const member function") {
-            const test_class<TestType>       obj;
-            snitch::small_function<TestType> f = {
+            const test_class<TestType>     obj;
+            snitch::function_ref<TestType> f = {
                 obj, snitch::constant<&test_class<TestType>::method_const>{}};
 
             call_function(f);
@@ -127,8 +127,8 @@ TEMPLATE_TEST_CASE(
         }
 
         SECTION("from stateless lambda") {
-            snitch::small_function<TestType> f =
-                snitch::small_function<TestType>{[](Args...) noexcept -> R {
+            snitch::function_ref<TestType> f =
+                snitch::function_ref<TestType>{[](Args...) noexcept -> R {
                     function_called = true;
                     if constexpr (!std::is_same_v<R, void>) {
                         return 45;
@@ -153,7 +153,7 @@ TEMPLATE_TEST_CASE(
                 }
             };
 
-            snitch::small_function<TestType> f = snitch::small_function<TestType>{lambda};
+            snitch::function_ref<TestType> f = snitch::function_ref<TestType>{lambda};
 
             call_function(f);
 
@@ -165,8 +165,8 @@ TEMPLATE_TEST_CASE(
         }
 
         SECTION("from other function") {
-            snitch::small_function<TestType> f1 = &test_class<TestType>::method_static;
-            snitch::small_function<TestType> f2(f1);
+            snitch::function_ref<TestType> f1 = &test_class<TestType>::method_static;
+            snitch::function_ref<TestType> f2(f1);
 
             call_function(f1);
 

--- a/tests/testing_assertions.hpp
+++ b/tests/testing_assertions.hpp
@@ -17,7 +17,7 @@ struct assertion_exception : public std::exception {
 };
 
 struct assertion_exception_enabler {
-    snitch::small_function<void(std::string_view)> prev_handler;
+    snitch::function_ref<void(std::string_view)> prev_handler;
 
     assertion_exception_enabler() : prev_handler(snitch::assertion_failed_handler) {
         snitch::assertion_failed_handler = [](std::string_view msg) {

--- a/tests/testing_event.hpp
+++ b/tests/testing_event.hpp
@@ -212,7 +212,7 @@ struct console_output_catcher {
     std::unique_ptr<large_data> data     = std::make_unique<large_data>();
     snitch::small_string<4086>& messages = data->messages;
 
-    snitch::small_function<void(std::string_view) noexcept> prev_print;
+    snitch::function_ref<void(std::string_view) noexcept> prev_print;
 
     console_output_catcher() : prev_print(snitch::cli::console_print) {
         snitch::cli::console_print = {*this, snitch::constant<&console_output_catcher::print>{}};


### PR DESCRIPTION
Closes #112.